### PR TITLE
remove num2words import

### DIFF
--- a/FinBert Model Example.ipynb
+++ b/FinBert Model Example.ipynb
@@ -542,7 +542,6 @@
     "from nltk.tokenize import word_tokenize\n",
     "from nltk.stem import PorterStemmer\n",
     "from collections import Counter\n",
-    "from num2words import num2words\n",
     "\n",
     "import nltk\n",
     "import os\n",


### PR DESCRIPTION
num2words is not used in the preprocessing and not required